### PR TITLE
Fix negative timeout in PollOneOff causing infinite wait

### DIFF
--- a/systems/unix/system.go
+++ b/systems/unix/system.go
@@ -235,6 +235,9 @@ func (s *System) PollOneOff(ctx context.Context, subscriptions []wasi.Subscripti
 			timeoutMillis = -1
 		case !deadline.IsZero():
 			timeoutMillis = int(time.Until(deadline).Milliseconds())
+			if timeoutMillis < 0 {
+				timeoutMillis = 0
+			}
 		}
 
 		n, err := unix.Poll(s.pollfds, timeoutMillis)


### PR DESCRIPTION
  ## Summary
  Fixed a bug in `PollOneOff` where negative timeout values could cause `unix.Poll` to wait indefinitely instead of respecting the intended deadline.

  ## Problem
  Between setting the `deadline` (line 226) and calculating `timeoutMillis` with `time.Until(deadline)` (line 237), time may elapse due to:
  - GC pauses
  - High CPU load
  - Scheduling delays
  - Other system events

  When this elapsed time exceeds the timeout duration, `time.Until(deadline)` returns a negative value. Since `unix.Poll` interprets negative timeout as infinite wait, the intended timeout is not honored.

  This issue can occur in various scenarios:
  - Before the first `Poll` call
  - During EINTR retry loops
  - After spurious wakeups
  - In high-load environments with scheduling delays

  ## Solution
  Clamp `timeoutMillis` to 0 when it becomes negative, ensuring `unix.Poll` returns immediately. This allows the timeout event to be properly processed.

  ## Impact
  - Improves stability in environments with frequent interruptions
  - Ensures timeout accuracy and better WASI spec compliance
  - Reduces risk of hangs in high-load scenarios
